### PR TITLE
Fix pool session checkin rollback (fire events)

### DIFF
--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -117,7 +117,7 @@ from sqlalchemy.engine import create_engine, engine_from_config
 __all__ = sorted(name for name, obj in locals().items()
                  if not (name.startswith('_') or inspect.ismodule(obj)))
 
-__version__ = '0.7.617kb'
+__version__ = '0.7.618kb'
 
 del inspect, sys
 

--- a/lib/sqlalchemy/dialects/drizzle/base.py
+++ b/lib/sqlalchemy/dialects/drizzle/base.py
@@ -522,16 +522,6 @@ class DrizzleDialect(mysql_dialect.MySQLDialect):
             conn.autocommit(False)
         return connect
 
-    def do_commit(self, connection):
-        """Execute a COMMIT."""
-
-        connection.commit()
-
-    def do_rollback(self, connection):
-        """Execute a ROLLBACK."""
-
-        connection.rollback()
-
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
         """Return a Unicode SHOW TABLES from a given schema."""

--- a/lib/sqlalchemy/dialects/firebird/base.py
+++ b/lib/sqlalchemy/dialects/firebird/base.py
@@ -691,10 +691,10 @@ class FBDialect(default.DefaultDialect):
         # when there are no arguments.
         cursor.execute(statement, parameters or [])
 
-    def do_rollback(self, connection):
+    def do_rollback(self, dbapi_connection):
         # Use the retaining feature, that keeps the transaction going
-        connection.rollback(True)
+        dbapi_connection.rollback(True)
 
-    def do_commit(self, connection):
+    def do_commit(self, dbapi_connection):
         # Use the retaining feature, that keeps the transaction going
-        connection.commit(True)
+        dbapi_connection.commit(True)

--- a/lib/sqlalchemy/dialects/informix/base.py
+++ b/lib/sqlalchemy/dialects/informix/base.py
@@ -349,10 +349,6 @@ class InformixDialect(default.DefaultDialect):
     preparer = InformixIdentifierPreparer
     default_paramstyle = 'qmark'
 
-    def __init__(self, has_transactions=True, *args, **kwargs):
-        self.has_transactions = has_transactions
-        default.DefaultDialect.__init__(self, *args, **kwargs)
-
     def initialize(self, connection):
         super(InformixDialect, self).initialize(connection)
 
@@ -361,20 +357,6 @@ class InformixDialect(default.DefaultDialect):
             self.max_identifier_length = 18
         else:
             self.max_identifier_length = 128
-
-    def do_begin(self, connection):
-        cu = connection.cursor()
-        cu.execute('SET LOCK MODE TO WAIT')
-        if self.has_transactions:
-            cu.execute('SET ISOLATION TO REPEATABLE READ')
-
-    def do_commit(self, connection):
-        if self.has_transactions:
-            connection.commit()
-
-    def do_rollback(self, connection):
-        if self.has_transactions:
-            connection.rollback()
 
     def _get_table_names(self, connection, schema, type, **kw):
         schema = schema or self.default_schema_name

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1857,7 +1857,7 @@ class MySQLDialect(default.DefaultDialect):
         cursor.close()
         return val.upper().replace("-", " ")
 
-    def do_commit(self, connection):
+    def do_commit(self, dbapi_connection):
         """Execute a COMMIT."""
 
         # COMMIT/ROLLBACK were introduced in 3.23.15.
@@ -1866,7 +1866,7 @@ class MySQLDialect(default.DefaultDialect):
         # Ignore commit/rollback if support isn't present, otherwise even basic
         # operations via autocommit fail.
         try:
-            connection.commit()
+            dbapi_connection.commit()
         except:
             if self.server_version_info < (3, 23, 15):
                 args = sys.exc_info()[1].args
@@ -1874,11 +1874,11 @@ class MySQLDialect(default.DefaultDialect):
                     return
             raise
 
-    def do_rollback(self, connection):
+    def do_rollback(self, dbapi_connection):
         """Execute a ROLLBACK."""
 
         try:
-            connection.rollback()
+            dbapi_connection.rollback()
         except:
             if self.server_version_info < (3, 23, 15):
                 args = sys.exc_info()[1].args

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -289,26 +289,17 @@ class DefaultDialect(base.Dialect):
         opts.update(url.query)
         return [[], opts]
 
-    def do_begin(self, connection):
-        """Implementations might want to put logic here for turning
-        autocommit on/off, etc.
-        """
-
+    def do_begin(self, dbapi_connection):
         pass
 
-    def do_rollback(self, connection):
-        """Implementations might want to put logic here for turning
-        autocommit on/off, etc.
-        """
+    def do_rollback(self, dbapi_connection):
+        dbapi_connection.rollback()
 
-        connection.rollback()
+    def do_commit(self, dbapi_connection):
+        dbapi_connection.commit()
 
-    def do_commit(self, connection):
-        """Implementations might want to put logic here for turning
-        autocommit on/off, etc.
-        """
-
-        connection.commit()
+    def do_close(self, dbapi_connection):
+        dbapi_connection.close()
 
     def create_xid(self):
         """Create a random two-phase transaction ID.

--- a/lib/sqlalchemy/events.py
+++ b/lib/sqlalchemy/events.py
@@ -333,6 +333,27 @@ class PoolEvents(event.Events):
 
         """
 
+    def reset(self, dbapi_con, con_record):
+        """Called before the "reset" action occurs for a pooled connection.
+        This event represents
+        when the ``rollback()`` method is called on the DBAPI connection
+        before it is returned to the pool.  The behavior of "reset" can
+        be controlled, including disabled, using the ``reset_on_return``
+        pool argument.
+        The :meth:`.PoolEvents.reset` event is usually followed by the
+        the :meth:`.PoolEvents.checkin` event is called, except in those
+        cases where the connection is discarded immediately after reset.
+        :param dbapi_con:
+          A raw DB-API connection
+        :param con_record:
+          The ``_ConnectionRecord`` that persistently manages the connection
+        .. versionadded:: 0.8
+        .. seealso::
+            :meth:`.ConnectionEvents.rollback`
+            :meth:`.ConnectionEvents.commit`
+        """
+
+
 class ConnectionEvents(event.Events):
     """Available events for :class:`.Connection`.
 

--- a/lib/sqlalchemy/pool.py
+++ b/lib/sqlalchemy/pool.py
@@ -62,9 +62,28 @@ reset_commit = util.symbol('reset_commit')
 reset_none = util.symbol('reset_none')
 
 
+class _ConnDialect(object):
+    """partial implementation of :class:`.Dialect`
+    which provides DBAPI connection methods.
+    When a :class:`.Pool` is combined with an :class:`.Engine`,
+    the :class:`.Engine` replaces this with its own
+    :class:`.Dialect`.
+    """
+    def do_rollback(self, dbapi_connection):
+        dbapi_connection.rollback()
+
+    def do_commit(self, dbapi_connection):
+        dbapi_connection.commit()
+
+    def do_close(self, dbapi_connection):
+        dbapi_connection.close()
+        
+
 class Pool(log.Identified):
     """Abstract base class for connection pools."""
 
+    _dialect = _ConnDialect()
+    
     def __init__(self, 
                     creator, recycle=-1, echo=None, 
                     use_threadlocal=False,
@@ -72,7 +91,8 @@ class Pool(log.Identified):
                     reset_on_return=True, 
                     listeners=None,
                     events=None,
-                    _dispatch=None):
+                    _dispatch=None,
+                    _dialect=None):
         """
         Construct a Pool.
 
@@ -148,6 +168,8 @@ class Pool(log.Identified):
         self.echo = echo
         if _dispatch:
             self.dispatch._update(_dispatch, only_propagate=False)
+        if _dialect:
+            self._dialect = _dialect
         if events:
             for fn, target in events:
                 event.listen(self, target, fn)
@@ -159,6 +181,16 @@ class Pool(log.Identified):
                 self.add_listener(l)
 
     dispatch = event.dispatcher(events.PoolEvents)
+
+    def _close_connection(self, connection):
+        self.logger.debug("Closing connection %r", connection)
+        try:
+            self._dialect.do_close(connection)
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except:
+            self.logger.debug("Exception closing connection %r",
+                            connection)
 
     @util.deprecated(2.7, "Pool.add_listener is deprecated.  Use event.listen()")
     def add_listener(self, listener):
@@ -275,14 +307,7 @@ class _ConnectionRecord(object):
 
     def close(self):
         if self.connection is not None:
-            self.__pool.logger.debug("Closing connection %r", self.connection)
-            try:
-                self.connection.close()
-            except (SystemExit, KeyboardInterrupt):
-                raise
-            except:
-                self.__pool.logger.debug("Exception closing connection %r",
-                                self.connection)
+            self.__pool._close_connection(self.connection)
 
     def invalidate(self, e=None):
         if e is not None:
@@ -314,15 +339,7 @@ class _ConnectionRecord(object):
         return self.connection
 
     def __close(self):
-        try:
-            self.__pool.logger.debug("Closing connection %r", self.connection)
-            self.connection.close()
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception, e:
-            self.__pool.logger.debug(
-                        "Connection %r threw an error on close: %s",
-                        self.connection, e)
+        self.__pool._close_connection(self.connection)
 
     def __connect(self):
         try:
@@ -344,13 +361,15 @@ def _finalize_fairy(connection, connection_record, pool, ref, echo):
 
     if connection is not None:
         try:
+            if pool.dispatch.reset:
+                pool.dispatch.reset(connection, connection_record)
             if pool._reset_on_return is reset_rollback:
-                connection.rollback()
+                pool._dialect.do_rollback(connection)
             elif pool._reset_on_return is reset_commit:
-                connection.commit()
+                pool._dialect.do_commit(connection)
             # Immediately close detached instances
             if connection_record is None:
-                connection.close()
+                pool._close_connection(connection)
         except Exception, e:
             if connection_record is not None:
                 connection_record.invalidate(e=e)
@@ -535,7 +554,8 @@ class SingletonThreadPool(Pool):
             echo=self.echo, 
             logging_name=self._orig_logging_name,
             use_threadlocal=self._use_threadlocal, 
-            _dispatch=self.dispatch)
+            _dispatch=self.dispatch,
+            _dialect=self._dialect)
 
     def dispose(self):
         """Dispose of this pool."""
@@ -694,7 +714,8 @@ class QueuePool(Pool):
                           recycle=self._recycle, echo=self.echo, 
                           logging_name=self._orig_logging_name,
                           use_threadlocal=self._use_threadlocal,
-                          _dispatch=self.dispatch)
+                          _dispatch=self.dispatch,
+                          _dialect=self._dialect)
 
     def _do_return_conn(self, conn):
         try:
@@ -807,7 +828,8 @@ class NullPool(Pool):
             echo=self.echo, 
             logging_name=self._orig_logging_name,
             use_threadlocal=self._use_threadlocal, 
-            _dispatch=self.dispatch)
+            _dispatch=self.dispatch,
+            _dialect=self._dialect)
 
     def dispose(self):
         pass
@@ -847,7 +869,8 @@ class StaticPool(Pool):
                               reset_on_return=self._reset_on_return,
                               echo=self.echo,
                               logging_name=self._orig_logging_name,
-                              _dispatch=self.dispatch)
+                              _dispatch=self.dispatch,
+                              _dialect=self._dialect)
 
     def _create_connection(self):
         return self._conn
@@ -896,7 +919,8 @@ class AssertionPool(Pool):
         self.logger.info("Pool recreating")
         return self.__class__(self._creator, echo=self.echo, 
                             logging_name=self._orig_logging_name,
-                            _dispatch=self.dispatch)
+                            _dispatch=self.dispatch,
+                            _dialect=self._dialect)
 
     def _do_get(self):
         if self._checked_out:


### PR DESCRIPTION
Fix sqlalchemy so the rollback that happens on check-in of sessions that never committed flow through the normal sqlalchemy and so fire events (which we need for https://github.com/RetailArchitects/loft/issues/9270)